### PR TITLE
Strict compiler options.

### DIFF
--- a/makefile
+++ b/makefile
@@ -1,10 +1,12 @@
 CXX=g++ -std=c++20
 INCLUDE=-Ilib -Itests
-RFLAGS=-Ofast -Wall
-DFLAGS=-g -Wall -D_GLIBCXX_DEBUG
+RFLAGS=-Ofast -Wall -Werror -Wextra -Wpedantic
+DFLAGS=-g -Wall -Werror -Wextra -Wpedantic -D_GLIBCXX_DEBUG
 DOXY=doxygen
 
 all: bin bin/test_release bin/test_debug docs
+debug: bin bin/test_debug
+release: bin bin/test_release
 bin/test_release: tests/tests.cpp
 	$(CXX) $(INCLUDE) $(RFLAGS) -o $@ $< $(LDLIBS)
 bin/test_debug: tests/tests.cpp

--- a/tests/tests.cpp
+++ b/tests/tests.cpp
@@ -10,7 +10,7 @@
 #include "test_iterator.hpp"
 #include "test_estimators.hpp"
 
-int main(int args, char* argv[]){
+int main(int, char* argv[]){
     std::cout << argv[0] << " test suite" << std::endl;
     int error = 0;
     error += testq_fmm_exp2_2d();


### PR DESCRIPTION
Add strict compiler options (Werror, Wpedantic, Wextra) and fix any assocated errors.